### PR TITLE
updating colors for alerts for better A11y

### DIFF
--- a/assets/css/dulcet.style.css
+++ b/assets/css/dulcet.style.css
@@ -1,4 +1,6 @@
 @charset "UTF-8";
+/* insufficient contrast as bg w/ white text */
+/* insufficient contrast as bg w/ white text */
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 @import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700");
 html {
@@ -1295,7 +1297,7 @@ a.bg-primary:focus {
   background-color: #032051; }
 
 .bg-success {
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
 
 a.bg-success:hover,
 a.bg-success:focus {
@@ -1316,11 +1318,11 @@ a.bg-warning:focus {
   background-color: #be7904; }
 
 .bg-danger {
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
 
 a.bg-danger:hover,
 a.bg-danger:focus {
-  background-color: #992600; }
+  background-color: #691201; }
 
 .page-header {
   padding-bottom: 11px;
@@ -2121,7 +2123,7 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.success,
 .table > tfoot > tr.success > td,
 .table > tfoot > tr.success > th {
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
 
 .table-hover > tbody > tr > td.success:hover,
 .table-hover > tbody > tr > th.success:hover,
@@ -2184,14 +2186,14 @@ table th[class*="col-"] {
 .table > tfoot > tr > th.danger,
 .table > tfoot > tr.danger > td,
 .table > tfoot > tr.danger > th {
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
 
 .table-hover > tbody > tr > td.danger:hover,
 .table-hover > tbody > tr > th.danger:hover,
 .table-hover > tbody > tr.danger:hover > td,
 .table-hover > tbody > tr:hover > .danger,
 .table-hover > tbody > tr.danger:hover > th {
-  background-color: #b32d00; }
+  background-color: #821702; }
 
 .table-responsive {
   overflow-x: auto;
@@ -2632,7 +2634,7 @@ select[multiple].input-lg,
 .has-success .input-group-addon {
   color: #fff;
   border-color: #fff;
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
 
 .has-success .form-control-feedback {
   color: #fff; }
@@ -2686,7 +2688,7 @@ select[multiple].input-lg,
 .has-error .input-group-addon {
   color: #fff;
   border-color: #fff;
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
 
 .has-error .form-control-feedback {
   color: #fff; }
@@ -2923,8 +2925,8 @@ fieldset[disabled] .media-widget > a {
 
 .btn-success {
   color: #fff;
-  background-color: #A1B70D;
-  border-color: #A1B70D; }
+  background-color: #a1b70d;
+  border-color: #a1b70d; }
   .btn-success:focus, .btn-success.focus {
     color: #fff;
     background-color: #77870a;
@@ -2952,10 +2954,10 @@ fieldset[disabled] .media-widget > a {
   fieldset[disabled] .btn-success:hover,
   fieldset[disabled] .btn-success:focus,
   fieldset[disabled] .btn-success.focus {
-    background-color: #A1B70D;
-    border-color: #A1B70D; }
+    background-color: #a1b70d;
+    border-color: #a1b70d; }
   .btn-success .badge {
-    color: #A1B70D;
+    color: #a1b70d;
     background-color: #fff; }
 
 .btn-info {
@@ -3034,28 +3036,28 @@ fieldset[disabled] .media-widget > a {
 
 .btn-danger {
   color: #fff;
-  background-color: #CC3300;
-  border-color: #CC3300; }
+  background-color: #9b1b02;
+  border-color: #9b1b02; }
   .btn-danger:focus, .btn-danger.focus {
     color: #fff;
-    background-color: #992600;
-    border-color: #4d1300; }
+    background-color: #691201;
+    border-color: #1d0500; }
   .btn-danger:hover {
     color: #fff;
-    background-color: #992600;
-    border-color: #8f2400; }
+    background-color: #691201;
+    border-color: #5f1001; }
   .btn-danger:active, .btn-danger.active,
   .open > .btn-danger.dropdown-toggle {
     color: #fff;
-    background-color: #992600;
-    border-color: #8f2400; }
+    background-color: #691201;
+    border-color: #5f1001; }
     .btn-danger:active:hover, .btn-danger:active:focus, .btn-danger:active.focus, .btn-danger.active:hover, .btn-danger.active:focus, .btn-danger.active.focus,
     .open > .btn-danger.dropdown-toggle:hover,
     .open > .btn-danger.dropdown-toggle:focus,
     .open > .btn-danger.dropdown-toggle.focus {
       color: #fff;
-      background-color: #751d00;
-      border-color: #4d1300; }
+      background-color: #450c01;
+      border-color: #1d0500; }
   .btn-danger:active, .btn-danger.active,
   .open > .btn-danger.dropdown-toggle {
     background-image: none; }
@@ -3063,10 +3065,10 @@ fieldset[disabled] .media-widget > a {
   fieldset[disabled] .btn-danger:hover,
   fieldset[disabled] .btn-danger:focus,
   fieldset[disabled] .btn-danger.focus {
-    background-color: #CC3300;
-    border-color: #CC3300; }
+    background-color: #9b1b02;
+    border-color: #9b1b02; }
   .btn-danger .badge {
-    color: #CC3300;
+    color: #9b1b02;
     background-color: #fff; }
 
 .btn-link {
@@ -4256,7 +4258,7 @@ a.label:hover, a.label:focus {
     background-color: #032051; }
 
 .label-success {
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
   .label-success[href]:hover, .label-success[href]:focus {
     background-color: #77870a; }
 
@@ -4271,9 +4273,9 @@ a.label:hover, a.label:focus {
     background-color: #be7904; }
 
 .label-danger {
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
   .label-danger[href]:hover, .label-danger[href]:focus {
-    background-color: #992600; }
+    background-color: #691201; }
 
 .badge {
   display: inline-block;
@@ -4400,7 +4402,7 @@ a.thumbnail.active {
     color: inherit; }
 
 .alert-success {
-  background-color: #A1B70D;
+  background-color: #a1b70d;
   border-color: #9f9a0b;
   color: #fff; }
   .alert-success hr {
@@ -4427,11 +4429,11 @@ a.thumbnail.active {
     color: #e6e6e6; }
 
 .alert-danger {
-  background-color: #CC3300;
-  border-color: #bd1000;
+  background-color: #9b1b02;
+  border-color: #8c0202;
   color: #fff; }
   .alert-danger hr {
-    border-top-color: #a30e00; }
+    border-top-color: #730102; }
   .alert-danger .alert-link {
     color: #e6e6e6; }
 
@@ -4471,7 +4473,7 @@ a.thumbnail.active {
   animation: progress-bar-stripes 2s linear infinite; }
 
 .progress-bar-success {
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
   .progress-striped .progress-bar-success {
     background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
@@ -4486,7 +4488,7 @@ a.thumbnail.active {
     background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
 .progress-bar-danger {
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
   .progress-striped .progress-bar-danger {
     background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent); }
 
@@ -4599,7 +4601,7 @@ button.list-group-item {
 
 .list-group-item-success {
   color: #fff;
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
 
 a.list-group-item-success,
 button.list-group-item-success {
@@ -4668,7 +4670,7 @@ button.list-group-item-warning {
 
 .list-group-item-danger {
   color: #fff;
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
 
 a.list-group-item-danger,
 button.list-group-item-danger {
@@ -4680,7 +4682,7 @@ button.list-group-item-danger {
   button.list-group-item-danger:hover,
   button.list-group-item-danger:focus {
     color: #fff;
-    background-color: #b32d00; }
+    background-color: #821702; }
   a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus,
   button.list-group-item-danger.active,
   button.list-group-item-danger.active:hover,
@@ -4983,12 +4985,12 @@ button.list-group-item-danger {
   border-color: #9f9a0b; }
   .panel-success > .panel-heading {
     color: #fff;
-    background-color: #A1B70D;
+    background-color: #a1b70d;
     border-color: #9f9a0b; }
     .panel-success > .panel-heading + .panel-collapse > .panel-body {
       border-top-color: #9f9a0b; }
     .panel-success > .panel-heading .badge {
-      color: #A1B70D;
+      color: #a1b70d;
       background-color: #fff; }
   .panel-success > .panel-footer + .panel-collapse > .panel-body {
     border-bottom-color: #9f9a0b; }
@@ -5022,18 +5024,18 @@ button.list-group-item-danger {
     border-bottom-color: #e16b05; }
 
 .panel-danger {
-  border-color: #bd1000; }
+  border-color: #8c0202; }
   .panel-danger > .panel-heading {
     color: #fff;
-    background-color: #CC3300;
-    border-color: #bd1000; }
+    background-color: #9b1b02;
+    border-color: #8c0202; }
     .panel-danger > .panel-heading + .panel-collapse > .panel-body {
-      border-top-color: #bd1000; }
+      border-top-color: #8c0202; }
     .panel-danger > .panel-heading .badge {
-      color: #CC3300;
+      color: #9b1b02;
       background-color: #fff; }
   .panel-danger > .panel-footer + .panel-collapse > .panel-body {
-    border-bottom-color: #bd1000; }
+    border-bottom-color: #8c0202; }
 
 .embed-responsive {
   position: relative;
@@ -7842,11 +7844,11 @@ body {
 
 .text-success,
 .text-success:hover {
-  color: #A1B70D; }
+  color: #a1b70d; }
 
 .text-danger,
 .text-danger:hover {
-  color: #CC3300; }
+  color: #9b1b02; }
 
 .text-warning,
 .text-warning:hover {
@@ -7896,22 +7898,22 @@ table .info,
 .has-error .help-block,
 .has-error .control-label,
 .has-error .form-control-feedback {
-  color: #CC3300; }
+  color: #9b1b02; }
 
 .has-error .form-control,
 .has-error .form-control:focus,
 .has-error .input-group-addon {
-  border: 1px solid #CC3300; }
+  border: 1px solid #9b1b02; }
 
 .has-success .help-block,
 .has-success .control-label,
 .has-success .form-control-feedback {
-  color: #A1B70D; }
+  color: #a1b70d; }
 
 .has-success .form-control,
 .has-success .form-control:focus,
 .has-success .input-group-addon {
-  border: 1px solid #A1B70D; }
+  border: 1px solid #a1b70d; }
 
 .nav-pills > li > a {
   border-radius: 0; }
@@ -7951,7 +7953,7 @@ table .info,
   color: #333333; }
 
 a.list-group-item-success.active {
-  background-color: #A1B70D; }
+  background-color: #a1b70d; }
 
 a.list-group-item-success.active:hover, a.list-group-item-success.active:focus {
   background-color: #8c9f0b; }
@@ -7963,10 +7965,10 @@ a.list-group-item-warning.active:hover, a.list-group-item-warning.active:focus {
   background-color: #d78904; }
 
 a.list-group-item-danger.active {
-  background-color: #CC3300; }
+  background-color: #9b1b02; }
 
 a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus {
-  background-color: #b32d00; }
+  background-color: #821702; }
 
 .modal .close {
   color: #333333; }
@@ -7993,7 +7995,7 @@ a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus {
     .comment .submitted .permalink {
       margin-left: 5px; }
     .comment .submitted .new {
-      color: #CC3300; }
+      color: #9b1b02; }
   .comment .content {
     margin: 10px 0; }
   .comment .links {
@@ -8645,8 +8647,6 @@ ul.dropdown-menu li {
 
 /* DUL Homepage Styles */
 /* VARIABLES */
-/* foo */
-/* Typography */
 /* Layout */
 .radix-dul {
   margin-top: 1em; }
@@ -10235,6 +10235,8 @@ ul.rl-collections li {
 .rl-hours-today .other {
   font-size: 14px; }
 
+/* insufficient contrast as bg w/ white text */
+/* insufficient contrast as bg w/ white text */
 .region-alerts .alert {
   margin-bottom: 15px;
   padding-top: 20px;
@@ -10248,6 +10250,62 @@ ul.rl-collections li {
   .page-home .region-alerts .alert {
     margin-top: 10px;
     margin-bottom: 0; }
+
+.alert {
+  /* blue */
+  /* green */
+  /* orange */
+  /* red */ }
+  .alert p a {
+    text-decoration: underline; }
+  .alert .close {
+    opacity: 0.7; }
+    .alert .close:hover {
+      opacity: 1.0; }
+  .alert.alert-info {
+    border-left: 10px solid #041b5e;
+    background-color: #053482;
+    color: #fff; }
+    .alert.alert-info p, .alert.alert-info a {
+      color: #fff; }
+    .alert.alert-info a.btn, .alert.alert-info .media-widget > a {
+      border-color: #041b5e;
+      background-color: #041b5e;
+      color: #c0cce0; }
+  .alert.alert-success {
+    border-left: 10px solid #a1b70d;
+    background-color: #e7edc2;
+    color: #4a6007; }
+    .alert.alert-success p, .alert.alert-success a {
+      color: #4a6007; }
+    .alert.alert-success a.btn, .alert.alert-success .media-widget > a {
+      border-color: #a1b70d;
+      background-color: #a1b70d;
+      color: #4a6007; }
+    .alert.alert-success .close:hover {
+      color: #4a6007; }
+  .alert.alert-warning {
+    border-left: 10px solid #F09905;
+    background-color: #f3e3c2;
+    color: #3c2c0b; }
+    .alert.alert-warning p, .alert.alert-warning a {
+      color: #3c2c0b; }
+    .alert.alert-warning a.btn, .alert.alert-warning .media-widget > a {
+      border-color: #F09905;
+      background-color: #F09905;
+      color: #3c2c0b; }
+    .alert.alert-warning .close:hover {
+      color: #3c2c0b; }
+  .alert.alert-danger {
+    border-left: 10px solid #6c1003;
+    background-color: #9b1b02;
+    color: #fff; }
+    .alert.alert-danger p, .alert.alert-danger a {
+      color: #fff; }
+    .alert.alert-danger a.btn, .alert.alert-danger .media-widget > a {
+      border-color: #6c1003;
+      background-color: #6c1003;
+      color: #e9cdc7; }
 
 html > .duke-alert {
   /* font-size: 14px; */ }
@@ -12841,7 +12899,7 @@ table[border="0"] thead, table[border="0"] tbody, table[border="0"] tr, table[bo
     color: #ccc;
     background: white; }
     .smallArrowNav a:hover {
-      background: #A1B70D;
+      background: #a1b70d;
       color: white; }
 
 .vertical-blogs a, .vertical-blogs a .blog-content {

--- a/scss/components/_dukealert.scss
+++ b/scss/components/_dukealert.scss
@@ -22,6 +22,101 @@
 }
 
 
+.alert {
+    p a {
+      text-decoration: underline;
+    }
+
+    .close {
+      opacity: 0.7;
+      &:hover {
+        opacity: 1.0;
+      }
+    }
+  
+    /* blue */
+    &.alert-info {
+      border-left: 10px solid $brand-primary-darker;
+      background-color: $brand-primary;
+      color: #fff;
+  
+      p, a {
+        color: #fff;
+      }
+  
+      a.btn {
+        border-color: $brand-primary-darker;
+        background-color: $brand-primary-darker;
+        color: $brand-primary-lighter;
+      }
+  
+    }
+  
+    /* green */
+    &.alert-success {
+      border-left: 10px solid $brand-success;
+      background-color: $brand-success-lighter;
+      color: $brand-success-darker;
+  
+      p, a {
+        color: $brand-success-darker;
+      }
+  
+      a.btn {
+        border-color: $brand-success;
+        background-color: $brand-success;
+        color: $brand-success-darker;
+      }
+  
+      .close:hover {
+        color: $brand-success-darker;
+      }
+  
+    }
+  
+    /* orange */
+    &.alert-warning {
+      border-left: 10px solid $brand-warning;
+      background-color: $brand-warning-lighter;
+      color: $brand-warning-darker;
+  
+      p, a {
+        color: $brand-warning-darker;
+      }
+  
+      a.btn {
+        border-color: $brand-warning;
+        background-color: $brand-warning;
+        color: $brand-warning-darker;
+      }
+  
+      .close:hover {
+        color: $brand-warning-darker;
+      }
+  
+    }
+  
+    /* red */
+    &.alert-danger {
+      border-left: 10px solid  $brand-danger-darker;
+      background-color: $brand-danger;
+      color: #fff;
+  
+      p, a {
+        color: #fff;
+      }
+  
+      a.btn {
+        border-color: $brand-danger-darker;
+        background-color: $brand-danger-darker;
+        color: $brand-danger-lighter;
+      }
+  
+    }
+  
+  }
+
+
 
 // Duke Alert
 // =======================

--- a/scss/dulcet/_dul-home.scss
+++ b/scss/dulcet/_dul-home.scss
@@ -8,13 +8,6 @@ $discovery-tabs-bg-off: #e8e5e2;
 $discovery-tabs-text: #fff;
 $discovery-tabs-text-off: #555;
 
-/* foo */
-
-/* Typography */
-
-
-
-
 
 /* Layout */
 

--- a/scss/dulcet/_variables.scss
+++ b/scss/dulcet/_variables.scss
@@ -3,9 +3,21 @@
 
 
 $brand-primary:         #053482;
-$brand-success:         #A1B70D;
-$brand-warning:         #F09905;
-$brand-danger:          #CC3300;
+$brand-primary-lighter: #c0cce0;
+$brand-primary-darker:  #041b5e;
+
+$brand-success:         #a1b70d; /* insufficient contrast as bg w/ white text */
+$brand-success-lighter: #e7edc2;
+$brand-success-darker:  #4a6007;
+
+$brand-warning:         #F09905; /* insufficient contrast as bg w/ white text */
+$brand-warning-lighter: #f3e3c2;
+$brand-warning-darker:  #3c2c0b;
+
+$brand-danger:          #9b1b02;
+$brand-danger-lighter:  #e9cdc7;
+$brand-danger-darker:   #6c1003;
+
 $brand-info:            #235F9C;
 
 


### PR DESCRIPTION
I could have sworn we updated the alert styles a couple of years ago, but apparently I'd only applied the styles for the duke alerts (doh!). This PR updates normal alerts in order to improve color contrast. Thumbnails attached below, and also viewable at http://pre.library.duke.edu/

![styleguide_examples](https://user-images.githubusercontent.com/2537019/57108031-9ee85f80-6cff-11e9-81f1-31d6620dee7a.png)
![homepage_example](https://user-images.githubusercontent.com/2537019/57108032-9f80f600-6cff-11e9-98a9-2672715c3f5b.png)
